### PR TITLE
Lw/cocoapods

### DIFF
--- a/PureJsonSerializer.podspec
+++ b/PureJsonSerializer.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'PureJsonSerializer'
+  spec.version      = '1.0.0'
+  spec.license      = { :type => 'Apache 2.0'}
+  spec.homepage     = 'https://github.com/gfx/Swift-JsonSerializer'
+  spec.authors      = { 'Goro Fuji' => 'gfuji@cpan.org' }
+  spec.summary      = 'A pure-Swift JSON serializer and deserializer'
+  spec.source       = { :git => 'https://github.com/gfx/Swift-JsonSerializer.git', :tag => "#{spec.version}" }
+  spec.source_files = 'JsonSerializer/*.{swift}'
+  spec.ios.deployment_target = "8.0"
+  spec.osx.deployment_target = "10.9"
+  spec.watchos.deployment_target = "2.0"
+  spec.tvos.deployment_target = "9.0"
+  spec.requires_arc = true
+  spec.social_media_url = 'https://twitter.com/__gfx__'
+end

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # Swift-JsonSerializer [![Build Status](https://travis-ci.org/gfx/Swift-JsonSerializer.svg)](https://travis-ci.org/gfx/Swift-JsonSerializer)
 
-A pure-Swift JSON parser and serializer
+A pure-Swift JSON parser and serializer.
 
-# SYNOPSIS
+# Cocoapods
 
+Lot's of Cocoapods means lots of failed namespaces. The actual pod for this library is called `PureJsonSerializer`.
+
+```Ruby
+pod 'PureJsonSerializer'
 ```
-import class JsonSerializer.JsonParser
-import enum JsonSerializer.Json
+
+# Deserialize
+
+```Swift
+import PureJsonSerializer
 
 // parse a JSON data
-let data: NSData
+let data: NSData = ...
 
-switch JsonParser.parse(data) {
-case .Success(let json):
-  println(json["foo"]["bar"].stringValue)
-case .Error(let error):
-  println(error)
+do {
+  let json = try Json.deserialize(jsonSource)
+  let value = json["Foo"]?["bar"]?.stringValue ?? ""
+  print(value)
+} catch {
+  print("Json serialization failed with error: \(error)")
 }
+```
 
+# Build
+
+```Swift
 // build a JSON structure
 let profile: Json = [
   "name": "Swift",
@@ -28,9 +40,15 @@ println(profile.description)      // packed JSON string
 println(profile.debugDescription) // pretty JSON string
 ```
 
+# Serialize
+
+```Swift
+let serializedJson = json.serialize(.PrettyPrint)
+```
+
 # DESCRIPTION
 
-Swift-JsonSerializer is a JSON serializer and deserializer which are implemented in **pure Swift** and adds nothing
+Swift-JsonSerializer is a JSON serializer and deserializer which are implemented in **Pure Swift** and adds nothing
 to built-in / standard classes in Swift.
 
 # KNOWN ISSUES

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A pure-Swift JSON parser and serializer.
 
-# Cocoapods
+# COCOAPODS
 
 Lot's of Cocoapods means lots of failed namespaces. The actual pod for this library is called `PureJsonSerializer`.
 
@@ -10,7 +10,7 @@ Lot's of Cocoapods means lots of failed namespaces. The actual pod for this libr
 pod 'PureJsonSerializer'
 ```
 
-# Deserialize
+# DESERIALIZE
 
 ```Swift
 import PureJsonSerializer
@@ -27,7 +27,7 @@ do {
 }
 ```
 
-# Build
+# BUILD
 
 ```Swift
 // build a JSON structure
@@ -40,7 +40,7 @@ println(profile.description)      // packed JSON string
 println(profile.debugDescription) // pretty JSON string
 ```
 
-# Serialize
+# SERIALIZE
 
 ```Swift
 let serializedJson = json.serialize(.PrettyPrint)
@@ -50,6 +50,10 @@ let serializedJson = json.serialize(.PrettyPrint)
 
 Swift-JsonSerializer is a JSON serializer and deserializer which are implemented in **Pure Swift** and adds nothing
 to built-in / standard classes in Swift.
+
+# GENOME
+
+This library is featured in a complete Json mapping library you can find <a href="https://github.com/LoganWright/Genome">here.</a>
 
 # KNOWN ISSUES
 


### PR DESCRIPTION
Hi @gfx 

I added cocoapods support for your library, a lot of the names were taken, so right now, the module is called `PureJsonSerializer`.  If you'd like to change it, it's relatively easy, or you can just make a new one.

If you want access to trunk, shoot me your email at any time and I can push control to you.  You can go here to get setup w/ trunk: https://guides.cocoapods.org/making/getting-setup-with-trunk.html

I also updated the readme to include some updated syntax examples and a cross link.  You can find the callback to your library <a href="https://github.com/LoganWright/Genome#purejsonserializer">here</a>.  Let me know if you'd prefer not to include these on either library.

Excited to have it up on Cocoapods, I think it's going to be a good addition!

Best,

Logan

